### PR TITLE
add missing tags

### DIFF
--- a/api/static/index.html
+++ b/api/static/index.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html xmlns="http://www.w3.org/1999/xhtml" xmlns:fb="http://ogp.me/ns/fb#">
     <head>
         <meta http-equiv="content-type" content="text/html; charset=UTF8" />
-        <meta name="description" content="Electricity Map | Real-time climate impact of the European electricity production" />
-
+        <meta name="description" content="Electricity Map is a real-time visualization of where your electricity comes from and how much greenhouse gas (GHG) was emitted to produce it." />
         <meta property="og:image" content="https://cloud.githubusercontent.com/assets/1655848/16257011/15711692-3856-11e6-98ca-95cce4d02b02.png" />
+        <meta property="og:description" content="Electricity Map is a real-time visualization of where your electricity comes from and how much greenhouse gas (GHG) was emitted to produce it." />
+        <meta property="og:url" content="http://electricitymap.tmrow.co" />
+        <meta property="og:type" content="website" />
+        <meta name="twitter:image" content="https://cloud.githubusercontent.com/assets/1655848/16257011/15711692-3856-11e6-98ca-95cce4d02b02.png">
+        <meta name="twitter:site" content="tmrowco">
         <meta property="og:title" content="Electricity Map | Real-time climate impact of the European electricity production" />
 
         <title>Electricity Map | Real-time climate impact of the European electricity production</title>


### PR DESCRIPTION
Added missing meta tags. 

_I also have experience that sometimes social media sites fail to unfurl the URLs, even if the tags are there. Might have something to do with timeouts.. they try to get the image in X seconds - if it takes longer, they show the post without image._

