### PR TITLE
Add PT parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Each country has a GHG mass flow that depends on neighboring countries. In order
 - Latvia: [energinet.dk](http://www.energinet.dk/EN/El/Sider/Det-nordiske-elsystem.aspx)
 - Lithuania: [energinet.dk](http://www.energinet.dk/EN/El/Sider/Det-nordiske-elsystem.aspx)
 - Norway: [energinet.dk](http://www.energinet.dk/EN/El/Sider/Det-nordiske-elsystem.aspx)
+- Portugal: [REN](http://www.centrodeinformacao.ren.pt/EN/InformacaoExploracao/Pages/EstatisticaDiaria.aspx)
 - Romania: [Transelectrica](http://www.transelectrica.ro/en/web/tel/home)
 - Spain: [REE](https://demanda.ree.es/generacion_acumulada.html)
 - Sweden: [energinet.dk](http://www.energinet.dk/EN/El/Sider/Det-nordiske-elsystem.aspx)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Each country has a GHG mass flow that depends on neighboring countries. In order
 - Norway
   - Hydro: [wikipedia.org](https://en.wikipedia.org/wiki/Electricity_sector_in_Norway)
   - Wind: [ieawind.org](http://www.ieawind.org/countries/norway.html)  
+- Portugal
+  - Hydro: [wikipedia.org](https://pt.wikipedia.org/wiki/Hidroel%C3%A9tricas_em_Portugal)
+  - Wind: [wikipedia.org](https://pt.wikipedia.org/wiki/Energia_eólica_em_Portugal)
+  - Solar: [wikipedia.org](https://pt.wikipedia.org/wiki/Energia_solar_em_Portugal)
 - Romania: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Spain: [ree.es](http://www.ree.es/sites/default/files/downloadable/preliminary_report_2014.pdf)
 - Sweden

--- a/api/static/app/countryconfig.js
+++ b/api/static/app/countryconfig.js
@@ -111,4 +111,9 @@ function addCountryConfiguration(countries) {
         solar: 79,
         wind: 6025
     };
+    countries['PT'].data.capacity = {
+        hydro: 5815,
+        solar: 57,
+        wind: 4730
+    };    
 }

--- a/api/static/app/exchangeconfig.js
+++ b/api/static/app/exchangeconfig.js
@@ -129,5 +129,11 @@ var EXCHANGES_CONFIG = [
         countries: ['HU', 'AT'],
         lonlat: [16.605363, 47.444264],
         rotation: -60
-    }
+    },
+    // PT
+    {
+        countries: ['PT', 'ES'],
+        lonlat: [-7, 40.0],
+        rotation: 90
+    },    
 ];

--- a/feeder/feeder.py
+++ b/feeder/feeder.py
@@ -13,6 +13,7 @@ from parsers.HU import fetch_HU
 from parsers.LT import fetch_LT
 from parsers.LV import fetch_LV
 from parsers.NO import fetch_NO
+from parsers.PT import fetch_PT
 from parsers.RO import fetch_RO
 from parsers.SE import fetch_SE
 
@@ -35,6 +36,7 @@ parsers = [
     fetch_LT,
     fetch_LV,
     fetch_NO,
+    fetch_PT,
     fetch_RO,
     fetch_SE
 ]

--- a/feeder/parsers/PT.py
+++ b/feeder/parsers/PT.py
@@ -3,6 +3,13 @@ from bs4 import BeautifulSoup
 
 COUNTRY_CODE = 'PT'
 
+def GWh_per_day_to_MW(energy_day_gwh):
+	hours_in_a_day = 24;
+
+	power_mw = energy_day_gwh / 24 * 1000;
+
+	return power_mw
+
 def fetch_PT():
 
 	r = requests.get('http://www.centrodeinformacao.ren.pt/EN/InformacaoExploracao/Pages/EstatisticaDiaria.aspx')
@@ -13,7 +20,7 @@ def fetch_PT():
 
 	for tr in trs:
 		value = tr.find_all("td")[2].string # Daily values are in column 3
-		value = float(value) # str -> float
+		value = GWh_per_day_to_MW(float(value)) # str -> float
 		daily_values.append(value)
 
 	date_str = soup.find(id="ctl00_m_g_5e80321e_76aa_4894_8c09_4e392fc3dc7d_txtDatePicker_foo")['value']

--- a/feeder/parsers/PT.py
+++ b/feeder/parsers/PT.py
@@ -1,0 +1,44 @@
+import requests, dateutil, arrow
+from bs4 import BeautifulSoup
+
+COUNTRY_CODE = 'PT'
+
+def fetch_PT():
+
+	r = requests.get('http://www.centrodeinformacao.ren.pt/EN/InformacaoExploracao/Pages/EstatisticaDiaria.aspx')
+	soup = BeautifulSoup(r.text, 'html.parser')
+
+	trs = soup.find_all("tr", { "class" : "grid_row" })
+	daily_values = []
+
+	for tr in trs:
+		value = tr.find_all("td")[2].string # Daily values are in column 3
+		value = float(value) # str -> float
+		daily_values.append(value)
+
+	date_str = soup.find(id="ctl00_m_g_5e80321e_76aa_4894_8c09_4e392fc3dc7d_txtDatePicker_foo")['value']
+	date = arrow.get(date_str, "DD-MM-YYYY").replace(tzinfo=dateutil.tz.gettz('Europe/Lisbon')).datetime
+
+
+	data = {
+		'countryCode': COUNTRY_CODE,
+		'datetime': date, # UTC
+		'production': {
+		    'wind': daily_values[9],
+		    'solar': daily_values[10],
+		    'hydro': daily_values[0] + daily_values[7], # There are 2 different production regimes
+		    'coal': daily_values[1] + daily_values[8] # There are 2 different production regimes
+		},
+		'consumption': {
+		    'unknown': daily_values[13]
+		},
+		'exchange':{
+			'ES': daily_values[3] - daily_values[4]
+		}
+
+	}
+
+	return data
+
+if __name__ == '__main__':
+    print fetch_PT()

--- a/feeder/requirements.txt
+++ b/feeder/requirements.txt
@@ -6,4 +6,5 @@ pymongo==3.2.2
 requests==2.10.0
 schedule==0.3.2
 xlrd==1.0.0
+beautifulsoup4==4.5.1
 -e git+https://github.com/gaelenh/python-statsd-client.git#egg=statsd-client

--- a/feeder/requirements.txt
+++ b/feeder/requirements.txt
@@ -1,4 +1,5 @@
 arrow==0.5.0
+beautifulsoup4==4.5.1
 Cython==0.23.4
 pandas==0.16.2
 pygrib==2.0.1
@@ -6,5 +7,4 @@ pymongo==3.2.2
 requests==2.10.0
 schedule==0.3.2
 xlrd==1.0.0
-beautifulsoup4==4.5.1
 -e git+https://github.com/gaelenh/python-statsd-client.git#egg=statsd-client


### PR DESCRIPTION
* Add parser for Portugal (PT) using data from http://www.centrodeinformacao.ren.pt/EN/InformacaoExploracao/Pages/EstatisticaDiaria.aspx

Note: Data is refreshed daily.. not as "real-time" as other sources but still thought it's better than having a grey country.