### PR TITLE
Changed the CO2 legend line from black to white 

### DIFF
--- a/web/public/css/styles.css
+++ b/web/public/css/styles.css
@@ -155,7 +155,7 @@ html, body {
     fill: black !important;
 }
 .co2-legend .x.axis line {
-    stroke: black !important;
+    stroke: white !important;
 }
 .co2-legend rect.border {
     stroke: black !important;


### PR DESCRIPTION
This is so that the line doesn't disappear on the black part of the bar.
