### PR TITLE
Update tooltip formatting

### DIFF
--- a/web/app/main.js
+++ b/web/app/main.js
@@ -362,18 +362,19 @@ if (isSmallScreen()) {
             tooltip.select('.emission-intensity')
                 .text(Math.round(co2intensity) || '?');
             var capacityFactor = Math.round(d.production / d.capacity * 100) || '?';
-            tooltip.select('#capacity-factor').text(
-                capacityFactor + ' %' +
-                ' (' + (formatPower(d.production) || '?') + ' ' +
+            tooltip.select('#capacity-factor').text(capacityFactor + ' %');
+            tooltip.select('#capacity-factor-detail').text(
+                (formatPower(d.production) || '?') + ' ' +
                 ' / ' + 
-                (formatPower(d.capacity) || '?') + ')');
+                (formatPower(d.capacity) || '?'));
             var totalProduction = countries[countryCode].totalProduction;
             var productionProportion = Math.round(d.production / totalProduction * 100) || '?';
             tooltip.select('#production-proportion').text(
-                productionProportion + ' %' +
-                ' (' + (formatPower(d.production) || '?') + ' ' +
+                productionProportion + ' %');
+            tooltip.select('#production-proportion-detail').text(
+                (formatPower(d.production) || '?') + ' ' +
                 ' / ' + 
-                (formatPower(totalProduction) || '?') + ')');
+                (formatPower(totalProduction) || '?'))
         })
         .onProductionMouseMove(function(d) {
             d3.select('#countrypanel-production-tooltip')

--- a/web/app/main.js
+++ b/web/app/main.js
@@ -356,7 +356,7 @@ if (isSmallScreen()) {
             co2Colorbar.currentMarker(co2intensity);
             var tooltip = d3.select('#countrypanel-production-tooltip');
             tooltip.style('display', 'inline');
-            tooltip.select('#mode').text(d.mode);
+            tooltip.selectAll('#mode').text(d.mode);
             tooltip.select('.emission-rect')
                 .style('background-color', co2intensity ? co2color(co2intensity) : 'gray');
             tooltip.select('.emission-intensity')

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -217,7 +217,7 @@
             <span id="production-proportion"></span> of total production<br />
             <small>(<span id="production-proportion-detail"></span>)</small><br />
             <br />
-            <span id="capacity-factor"></span> of installed capacity<br />
+            <span id="capacity-factor"></span> of installed <span id="mode"></span> capacity<br />
             <small>(<span id="capacity-factor-detail"></span>)</small>
         </div>
         <div id="countrypanel-exchange-tooltip" class="tooltip panel">

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -214,11 +214,11 @@
             Carbon intensity of <span id="mode" style="font-weight: bold;"></span>:<br />
             <div class="emission-rect"></div> <span class="emission-intensity"></span> gCO2eq/kWh<br />
             <br />
-            Proportion of total production:<br />
-            <div id="production-proportion"></div>
+            <span id="production-proportion"></span> of total production<br />
+            <small>(<span id="production-proportion-detail"></span>)</small><br />
             <br />
-            Capacity factor:<br />
-            <div id="capacity-factor"></div>
+            <span id="capacity-factor"></span> of installed capacity<br />
+            <small>(<span id="capacity-factor-detail"></span>)</small>
         </div>
         <div id="countrypanel-exchange-tooltip" class="tooltip panel">
             Carbon intensity of <span id="label"></span><br />


### PR DESCRIPTION
I took a few minutes to update and make more user-friendly the tooltip formatting.

Before:
![image](https://cloud.githubusercontent.com/assets/1655848/21932782/9985bf26-d9a2-11e6-8ccd-ecbf27d8e907.png)

After:
![image](https://cloud.githubusercontent.com/assets/1655848/21932868/068ef858-d9a3-11e6-8294-2307e5448de3.png)
