### PR TITLE
[Mobile] Fix display of countries

### DIFF
--- a/web/app/main.js
+++ b/web/app/main.js
@@ -494,7 +494,7 @@ function dataLoaded(err, state, argSolar, argWind) {
     // Render country picker if we're on mobile
     if (isSmallScreen()) {
         var validCountries = d3.values(countries).filter(function(d) {
-            return d.source;
+            return d.co2intensity;
         }).sort(function(x, y) {
             if (!x.co2intensity && !x.countryCode)
                 return d3.ascending(x.shortname || x.countryCode,

--- a/web/app/main.js
+++ b/web/app/main.js
@@ -494,7 +494,7 @@ function dataLoaded(err, state, argSolar, argWind) {
     // Render country picker if we're on mobile
     if (isSmallScreen()) {
         var validCountries = d3.values(countries).filter(function(d) {
-            return d.production;
+            return d.source;
         }).sort(function(x, y) {
             if (!x.co2intensity && !x.countryCode)
                 return d3.ascending(x.shortname || x.countryCode,


### PR DESCRIPTION
## What's the change ? 

This fixes https://github.com/corradio/electricitymap/issues/290. 

The problem was that the filter function used `production` attributes which existed for all countries displayed. 

I propose to use `source` attribute, which exists only if electricity production data exists. 

## What's the test ? 

I tested locally by emulating a mobile client in Chrome. It works nicely : 

<img width="594" alt="screen shot 2017-01-15 at 10 23 17 pm" src="https://cloud.githubusercontent.com/assets/695006/21972837/43d5c082-db71-11e6-9dbc-989c608a9ec9.png">

## Reviewers 

@corradio, @ThierryOllivero
