### PR TITLE
Fix CO2 imports

### DIFF
--- a/web/app/co2eq.js
+++ b/web/app/co2eq.js
@@ -10,7 +10,8 @@ exports.compute = function(countries) {
         .filter(function (d) { return d.countryCode && d.production; })
         .filter(function (d) {
             // Double check that total production + import >= export
-            return (d.totalProduction + d.totalImport) >= d.totalExport;
+            return (d.totalProduction + d.totalImport) >= d.totalExport &&
+                d.totalProduction > 0;
         })
         .filter(function (d) { return d.countryCode != 'NL'; });
     var validCountryKeys = validCountries.map(function (d) { return d.countryCode });
@@ -31,11 +32,12 @@ exports.compute = function(countries) {
 
     validCountries.forEach(function (country, i) {
         A.set([i, i], country.totalProduction + country.totalImport);
-        // Intern
+        // Production
         d3.entries(country.production).forEach(function (production) {
             var footprint = co2eq_parameters.footprintOf(production.key, country.countryCode);
             if (footprint === undefined) {
-                console.warn(country.countryCode + ' CO2 footprint of ' + production.key + ' is unknown');
+                // This is a fatal error: we shouldn't proceed beyond that point.
+                console.error(country.countryCode + ' CO2 footprint of ' + production.key + ' is unknown');
                 return;
             }
             // Accumulate
@@ -44,15 +46,17 @@ exports.compute = function(countries) {
         // Exchanges
         if (country.exchange) {
             d3.entries(country.exchange).forEach(function (exchange) {
+                // Only look at imports (exports cancel out)
                 if (exchange.value > 0) {
                     var j = validCountryKeys.indexOf(exchange.key);
                     if (j < 0) {
-                        if (typeof require == 'undefined')
-                            console.warn(country.countryCode + ' neighbor ' + exchange.key + ' has no co2 data');
-                        return;
+                        // The country we're importing from is not one
+                        // we're solving for.
+                        // Let's therefore give it the footprint of this country.
+                        A.set([i, i], A.get([i, i]) - exchange.value);
+                    } else {
+                        A.set([i, j], -exchange.value);
                     }
-                    // Import
-                    A.set([i, j], -exchange.value);
                 }
             });
         }

--- a/web/server.js
+++ b/web/server.js
@@ -141,8 +141,12 @@ function computeCo2(countries, exchanges) {
     d3.values(countries).forEach(function(country) {
         country.exchangeCo2Intensities = {};
         d3.keys(country.exchange).forEach(function(k) {
+            // Note that for imports of countries with unknown co2intensity
+            // the current country co2intensity is used (see co2eq.js)
             country.exchangeCo2Intensities[k] =
-                country.exchange[k] > 0 ? assignments[k] : country.co2intensity;
+                country.exchange[k] > 0 ?
+                    (assignments[k] || country.co2intensity) :
+                    country.co2intensity;
         });
         country.productionCo2Intensities = {};
         d3.keys(country.production).forEach(function(k) {


### PR DESCRIPTION
Fix #303 

What was done:
- Use this country's co2 intensity for imports from countries without co2 intensity
- Make sure we only calculate co2 intensity for countries having > 0 production (this fixes ME being at 0 co2 because we have no data).

Here's a before/after for LT, where the left panel shows emissions:

Before:
![image](https://cloud.githubusercontent.com/assets/1655848/22151687/72f94d64-df1f-11e6-970e-f70678b57e4f.png)

After:
![image](https://cloud.githubusercontent.com/assets/1655848/22151671/583f4294-df1f-11e6-933c-eb09b0adf22e.png)
