### PR TITLE
Updated GB and GB-NIR capacities

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,7 @@ Each country has a GHG mass flow that depends on neighboring countries. In order
 - Germany: 
   - [Fraunhofer ISE](https://www.energy-charts.de/power_inst.htm)
   - [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
-- Great Britain
-  - Gas: [energy-uk.org.uk](http://www.energy-uk.org.uk/energy-industry/gas-generation.html)
-  - Hydro: [wikipedia.org](https://en.wikipedia.org/wiki/Hydroelectricity_in_the_United_Kingdom)
-  - Nuclear: [wikipedia.org](https://en.wikipedia.org/wiki/Nuclear_power_in_the_United_Kingdom)
-  - Solar: [wikipedia.org](https://en.wikipedia.org/wiki/Solar_power_by_country)
-  - Wind: [wikipedia.org](https://en.wikipedia.org/wiki/Wind_power_in_the_United_Kingdom)
+- Great Britain: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Greece: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Hungary: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Ireland
@@ -93,6 +88,7 @@ Each country has a GHG mass flow that depends on neighboring countries. In order
   - Gas: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
   - Hydro: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
   - Wind: [ieawind.org](http://www.ieawind.org/countries/norway.html)  
+- Northern Irland: [EIR Grid](http://www.eirgridgroup.com/site-files/library/EirGrid/Generation_Capacity_Statement_20162025_FINAL.pdf)
 - Poland: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Portugal: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Romania: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Each country has a GHG mass flow that depends on neighboring countries. In order
   - Gas: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
   - Hydro: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
   - Wind: [ieawind.org](http://www.ieawind.org/countries/norway.html)  
-- Northern Irland: [EIR Grid](http://www.eirgridgroup.com/site-files/library/EirGrid/Generation_Capacity_Statement_20162025_FINAL.pdf)
+- Northern Ireland: [EIR Grid](http://www.eirgridgroup.com/site-files/library/EirGrid/Generation_Capacity_Statement_20162025_FINAL.pdf)
 - Poland: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Portugal: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Romania: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)

--- a/web/app/configs/capacities.json
+++ b/web/app/configs/capacities.json
@@ -112,16 +112,15 @@
     },
     "GB": {
         "capacity": {
-            "wind": 13573,
-            "nuclear": 8981,
-            "hydro": 4284,
-            "gas": 25702,
-            "solar": 8780,
-            "coal": 14889,
-            "biomass": 1890,
-            "oil": 792,
-            "solar": 3954,
-            "unknown": 4501
+            "wind": 15621,
+            "nuclear": 8985,
+            "hydro": 4269,
+            "gas": 27688,
+            "solar": 8566,
+            "coal": 11097,
+            "biomass": 2119,
+            "oil": 759,
+            "unknown": 8186
         }
     },
     "GB-NIR": {

--- a/web/app/configs/capacities.json
+++ b/web/app/configs/capacities.json
@@ -112,11 +112,16 @@
     },
     "GB": {
         "capacity": {
-            "wind": 13500,
-            "nuclear": 9000,
-            "hydro": 1550,
-            "gas": 38000,
-            "solar": 8780
+            "wind": 13573,
+            "nuclear": 8981,
+            "hydro": 4284,
+            "gas": 25702,
+            "solar": 8780,
+            "coal": 14889,
+            "biomass": 1890,
+            "oil": 792,
+            "solar": 3954,
+            "other": 4501
         }
     },
     "GB-NIR": {

--- a/web/app/configs/capacities.json
+++ b/web/app/configs/capacities.json
@@ -121,7 +121,7 @@
             "biomass": 1890,
             "oil": 792,
             "solar": 3954,
-            "other": 4501
+            "unknown": 4501
         }
     },
     "GB-NIR": {

--- a/web/app/configs/capacities.json
+++ b/web/app/configs/capacities.json
@@ -119,6 +119,16 @@
             "solar": 8780
         }
     },
+    "GB-NIR": {
+        "capacity": {
+            "wind": 863,
+            "gas": 1004,
+            "solar": 77,
+            "coal": 764,
+            "biomass": 35,
+            "oil": 415
+        }
+    },
     "GR": {
         "capacity": {
             "biomass": 51,


### PR DESCRIPTION
NIR based on EIR Grid http://www.eirgridgroup.com/site-files/library/EirGrid/Generation_Capacity_Statement_20162025_FINAL.pdf

GB based on ENTSOE 2017. 